### PR TITLE
Feature/arcadia add input autocomplete

### DIFF
--- a/src/components/Images/ImageWithPlaceHolder.tsx
+++ b/src/components/Images/ImageWithPlaceHolder.tsx
@@ -6,12 +6,19 @@ type ImagePropsType = {
   borderRadius: string,
   maxWidth: string,
   height: string,
-  placeHolderImage: JSX.Element
+  placeHolderImage: JSX.Element,
+  lazyLoad: boolean
+}
+
+enum ImgLoadType {
+  LAZY = 'lazy',
+  EAGER = 'eager',
 }
 
 export function ImageWithPlaceHolder(props: ImagePropsType) {
-  const { height, borderRadius, maxWidth, src, alt, placeHolderImage } = props;
+  const { height, borderRadius, maxWidth, src, alt, placeHolderImage, lazyLoad } = props;
   const [isError, setIsError] = useState(false);
+  const imgLoadingStrategy: ImgLoadType = lazyLoad ? ImgLoadType.LAZY : ImgLoadType.EAGER;
 
   if (isError) {
     return (
@@ -24,6 +31,7 @@ export function ImageWithPlaceHolder(props: ImagePropsType) {
   return (
     <img
       style={{ borderRadius, maxWidth }}
+      loading={imgLoadingStrategy}
       src={src}
       alt={alt}
       height={height}

--- a/src/components/Input/MultiTextInputWithAutocomplete.tsx
+++ b/src/components/Input/MultiTextInputWithAutocomplete.tsx
@@ -1,0 +1,148 @@
+import {
+  ArcAddInputContainer,
+  ArcInput,
+  ArcInputTitle,
+  AutoCompleteContainer,
+} from '@/views/search/arcadia/styles/arcadiaStyles';
+import React, { ChangeEventHandler, KeyboardEventHandler, useEffect, useState, useRef } from 'react';
+import { appendStringBeforeFirstComma, stripBeforeLastComma } from '@/utils/utils';
+
+type MultiTextInputWithAutocompleteProps = {
+  label ?: string,
+  title: string,
+  defaultValue ?: string,
+  autocompleteOptions: string[],
+  isInputActive ?: boolean,
+  inputRef: React.MutableRefObject<any>,
+}
+
+function MultiTextInputWithAutocomplete(props: MultiTextInputWithAutocompleteProps) {
+  const { label, defaultValue, title, autocompleteOptions, isInputActive, inputRef } = props;
+  const [inputValue, setInputValue] = useState('');
+  const [showAutoCompleteOptions, setShowAutoCompleteOptions] = useState(false);
+  const [activeItemIndex, setActiveItemIndex] = useState(0);
+  const [listValues, setListValues] = useState([]);
+  const itemRefs: React.MutableRefObject<{}> = useRef({});
+
+  useEffect(() => {
+    if (inputValue !== '') {
+      const MAX_OPTIONS: number = 50;
+      const filteredOptions: string[] = autocompleteOptions.filter((item) => item.includes(
+        stripBeforeLastComma(inputValue),
+      )).slice(0, MAX_OPTIONS);
+
+      if (filteredOptions.length > 0) {
+        setListValues(filteredOptions);
+        setShowAutoCompleteOptions(true);
+      } else {
+        setShowAutoCompleteOptions(false);
+      }
+    } else {
+      setShowAutoCompleteOptions(false);
+    }
+  }, [inputValue]);
+
+  useEffect(() => {
+    if (itemRefs.current[`${activeItemIndex}`]) {
+      itemRefs.current[`${activeItemIndex}`].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [activeItemIndex]);
+
+  const addOptionToInput = (capturedTag: string) => {
+    if (capturedTag !== '') {
+      const newInputValue: string = appendStringBeforeFirstComma(
+        inputRef.current.value,
+        capturedTag,
+      );
+      setInputValue('');
+      setListValues([]);
+      setActiveItemIndex(0);
+      inputRef.current.value = newInputValue;
+    }
+  };
+
+  const onInputChange: ChangeEventHandler = () => {
+    setInputValue(inputRef.current.value);
+  };
+
+  const handleBlur = () => {
+    setShowAutoCompleteOptions(false);
+  };
+
+  const onInputKeydown: KeyboardEventHandler = (e) => {
+    const specialKeys: string[] = ['ArrowUp', 'ArrowDown', 'Enter', 'Escape'];
+
+    if (specialKeys.includes(e.key)) {
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveItemIndex((prevIndex) => Math.max(prevIndex - 1, 0));
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveItemIndex((prevIndex) => Math.min(prevIndex + 1, listValues.length - 1));
+      } else if (e.key === 'Enter') {
+        if (showAutoCompleteOptions) {
+          e.preventDefault();
+          setShowAutoCompleteOptions(false);
+          addOptionToInput(listValues[activeItemIndex]);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        setShowAutoCompleteOptions(false);
+        setInputValue('');
+        setListValues([]);
+        setActiveItemIndex(0);
+      }
+    }
+  };
+
+  const addOptionOnclick = (index: number) => {
+    // Needed for pushing this action to the end of the call stack, in case other functions need
+    // to resolve before the <li> elements disappear. An example is the useClickOutside hook.
+    setTimeout(() => {
+      addOptionToInput(listValues[index]);
+      inputRef.current.focus();
+    }, 0);
+  };
+
+  const addToListItemRefs = (index: number, e: HTMLLIElement) => {
+    itemRefs.current[`${index}`] = e;
+  };
+
+  const autoCompleteOptionList: JSX.Element[] = listValues.map((item: string, index: number) => (
+    <li
+      key={item}
+      ref={(e: HTMLLIElement) => (addToListItemRefs(index, e))}
+      onMouseEnter={() => setActiveItemIndex(index)}
+      onMouseDown={() => addOptionOnclick(index)}
+      className={index === activeItemIndex ? 'active' : ''}
+    >
+      {item}
+    </li>
+  ));
+
+  return (
+    <ArcAddInputContainer onBlur={handleBlur}>
+      <ArcInputTitle>{label}</ArcInputTitle>
+      <ArcInput
+        title={title}
+        type="text"
+        defaultValue={defaultValue}
+        ref={inputRef}
+        disabled={!isInputActive}
+        onKeyDown={onInputKeydown}
+        onChange={onInputChange}
+      />
+      <AutoCompleteContainer show={showAutoCompleteOptions}>
+        {autoCompleteOptionList}
+      </AutoCompleteContainer>
+    </ArcAddInputContainer>
+  );
+}
+
+MultiTextInputWithAutocomplete.defaultProps = {
+  label: '',
+  defaultValue: '',
+  isInputActive: true,
+};
+
+export default MultiTextInputWithAutocomplete;

--- a/src/components/Input/MultiTextInputWithAutocomplete.tsx
+++ b/src/components/Input/MultiTextInputWithAutocomplete.tsx
@@ -7,12 +7,13 @@ import {
 import React, { ChangeEventHandler, KeyboardEventHandler, useEffect, useState, useRef } from 'react';
 import { appendStringBeforeFirstComma, stripBeforeLastComma } from '@/utils/utils';
 import { IStringIndexedObject } from '@/views/search/types/searchTypes';
+import { TagWithCount } from '@/dataSource/types/apiTypes';
 
 type MultiTextInputWithAutocompleteProps = {
   label ?: string,
   title: string,
   defaultValue ?: string,
-  autocompleteOptions: string[],
+  autocompleteOptions: TagWithCount[],
   isInputActive ?: boolean,
   inputRef: React.MutableRefObject<any>,
 }
@@ -28,9 +29,11 @@ function MultiTextInputWithAutocomplete(props: MultiTextInputWithAutocompletePro
   useEffect(() => {
     if (inputValue !== '') {
       const MAX_OPTIONS: number = 50;
-      const filteredOptions: string[] = autocompleteOptions.filter((item) => item.includes(
-        stripBeforeLastComma(inputValue),
-      )).slice(0, MAX_OPTIONS);
+      const filteredOptions: TagWithCount[] = autocompleteOptions.filter(
+        (item) => item.tag.includes(
+          stripBeforeLastComma(inputValue),
+        ),
+      ).slice(0, MAX_OPTIONS);
 
       if (filteredOptions.length > 0) {
         setListValues(filteredOptions);
@@ -84,7 +87,7 @@ function MultiTextInputWithAutocomplete(props: MultiTextInputWithAutocompletePro
         if (showAutoCompleteOptions) {
           e.preventDefault();
           setShowAutoCompleteOptions(false);
-          addOptionToInput(listValues[activeItemIndex]);
+          addOptionToInput(listValues[activeItemIndex].tag);
         }
       } else if (e.key === 'Escape') {
         e.preventDefault();
@@ -100,7 +103,7 @@ function MultiTextInputWithAutocomplete(props: MultiTextInputWithAutocompletePro
     // Needed for pushing this action to the end of the call stack, in case other functions need
     // to resolve before the <li> elements disappear. An example is the useClickOutside hook.
     setTimeout(() => {
-      addOptionToInput(listValues[index]);
+      addOptionToInput(listValues[index].tag);
       inputRef.current.focus();
     }, 0);
   };
@@ -109,17 +112,20 @@ function MultiTextInputWithAutocomplete(props: MultiTextInputWithAutocompletePro
     itemRefs.current[`${index}`] = e;
   };
 
-  const autoCompleteOptionList: JSX.Element[] = listValues.map((item: string, index: number) => (
-    <li
-      key={item}
-      ref={(e: HTMLLIElement) => (addToListItemRefs(index, e))}
-      onMouseEnter={() => setActiveItemIndex(index)}
-      onMouseDown={() => addOptionOnclick(index)}
-      className={index === activeItemIndex ? 'active' : ''}
-    >
-      {item}
-    </li>
-  ));
+  const autoCompleteOptionList: JSX.Element[] = listValues.map(
+    (item: TagWithCount, index: number) => (
+      <li
+        key={item.tag}
+        ref={(e: HTMLLIElement) => (addToListItemRefs(index, e))}
+        onMouseEnter={() => setActiveItemIndex(index)}
+        onMouseDown={() => addOptionOnclick(index)}
+        className={index === activeItemIndex ? 'active' : ''}
+      >
+        <span className="left">{item.tag}</span>
+        <span className="right">{item.count}</span>
+      </li>
+    )
+  );
 
   return (
     <ArcAddInputContainer onBlur={handleBlur}>

--- a/src/components/Input/MultiTextInputWithAutocomplete.tsx
+++ b/src/components/Input/MultiTextInputWithAutocomplete.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/views/search/arcadia/styles/arcadiaStyles';
 import React, { ChangeEventHandler, KeyboardEventHandler, useEffect, useState, useRef } from 'react';
 import { appendStringBeforeFirstComma, stripBeforeLastComma } from '@/utils/utils';
+import { IStringIndexedObject } from '@/views/search/types/searchTypes';
 
 type MultiTextInputWithAutocompleteProps = {
   label ?: string,
@@ -22,7 +23,7 @@ function MultiTextInputWithAutocomplete(props: MultiTextInputWithAutocompletePro
   const [showAutoCompleteOptions, setShowAutoCompleteOptions] = useState(false);
   const [activeItemIndex, setActiveItemIndex] = useState(0);
   const [listValues, setListValues] = useState([]);
-  const itemRefs: React.MutableRefObject<{}> = useRef({});
+  const itemRefs: React.MutableRefObject<IStringIndexedObject> = useRef({});
 
   useEffect(() => {
     if (inputValue !== '') {

--- a/src/context/searchContext.tsx
+++ b/src/context/searchContext.tsx
@@ -2,9 +2,11 @@ import React, { useReducer, useMemo, createContext } from 'react';
 import { SearchActionsEnum } from '@/context/types/enums';
 import { ChildrenProps } from '@/types';
 import { SearchContextActionType, SearchContextStateType } from '@/context/types/searchContextTypes';
+import { TagWithCount } from '@/dataSource/types/apiTypes';
 
 const initialState: SearchContextStateType = {
   tags: [],
+  tagsHashMap: new Map<string, number>(),
 };
 
 export const SearchContext = createContext({
@@ -14,11 +16,18 @@ export const SearchContext = createContext({
 
 const searchReducer = (state: SearchContextStateType, action: SearchContextActionType) => {
   switch (action.type) {
-    case SearchActionsEnum.LOAD_TAGS:
+    case SearchActionsEnum.LOAD_TAGS: {
+      const newTagMap: Map<string, number> = new Map<string, number>();
+      action.value.forEach((tagObject: TagWithCount) => {
+        newTagMap.set(tagObject.tag, tagObject.count);
+      });
+
       return {
         ...state,
         tags: action.value,
+        tagsHashMap: newTagMap,
       };
+    }
     default:
       return state;
   }

--- a/src/context/searchContext.tsx
+++ b/src/context/searchContext.tsx
@@ -1,0 +1,36 @@
+import React, { useReducer, useMemo, createContext } from 'react';
+import { SearchActionsEnum } from '@/context/types/enums';
+import { ChildrenProps } from '@/types';
+import { SearchContextActionType, SearchContextStateType } from '@/context/types/searchContextTypes';
+
+const initialState: SearchContextStateType = {
+  tags: [],
+};
+
+export const SearchContext = createContext({
+  state: initialState,
+  dispatch: null,
+});
+
+const searchReducer = (state: SearchContextStateType, action: SearchContextActionType) => {
+  switch (action.type) {
+    case SearchActionsEnum.LOAD_TAGS:
+      return {
+        ...state,
+        tags: action.value,
+      };
+    default:
+      return state;
+  }
+};
+
+export default function SearchProvider({ children }: ChildrenProps) {
+  const [state, dispatch] = useReducer(searchReducer, initialState);
+  const memoizedValue = useMemo(() => ({ state, dispatch }), [state]);
+
+  return (
+    <SearchContext.Provider value={memoizedValue}>
+      { children }
+    </SearchContext.Provider>
+  );
+}

--- a/src/context/types/enums.ts
+++ b/src/context/types/enums.ts
@@ -2,6 +2,10 @@ export enum GlobalActionsEnum {
   TOGGLE_THEME = 'TOGGLE_THEME'
 }
 
+export enum SearchActionsEnum {
+  LOAD_TAGS = 'LOAD_TAGS'
+}
+
 export enum Wh00tActionsEnum {
   WINDOW_MIN = 'WINDOW_MIN',
   WINDOW_MED = 'WINDOW_MED',

--- a/src/context/types/searchContextTypes.ts
+++ b/src/context/types/searchContextTypes.ts
@@ -1,10 +1,11 @@
 import { SearchActionsEnum } from '@/context/types/enums';
+import { TagWithCount } from '@/dataSource/types/apiTypes';
 
 export type SearchContextStateType = {
-  tags: string[]
+  tags: TagWithCount[]
 }
 
 export type SearchContextActionType = {
   type: SearchActionsEnum,
-  value: string[]
+  value: TagWithCount[]
 }

--- a/src/context/types/searchContextTypes.ts
+++ b/src/context/types/searchContextTypes.ts
@@ -2,7 +2,8 @@ import { SearchActionsEnum } from '@/context/types/enums';
 import { TagWithCount } from '@/dataSource/types/apiTypes';
 
 export type SearchContextStateType = {
-  tags: TagWithCount[]
+  tags: TagWithCount[],
+  tagsHashMap: Map<string, number>
 }
 
 export type SearchContextActionType = {

--- a/src/context/types/searchContextTypes.ts
+++ b/src/context/types/searchContextTypes.ts
@@ -1,0 +1,10 @@
+import { SearchActionsEnum } from '@/context/types/enums';
+
+export type SearchContextStateType = {
+  tags: string[]
+}
+
+export type SearchContextActionType = {
+  type: SearchActionsEnum,
+  value: string[]
+}

--- a/src/dataSource/restApis/bindRestApi.ts
+++ b/src/dataSource/restApis/bindRestApi.ts
@@ -30,7 +30,8 @@ export const lexiconApiEndpoints: LexiconEndpointsType = {
 export const arcadiaApiEndpoints: ArcadiaEndpointsType = {
   summary: '/arcadia/summary',
   randomTags: '/arcadia/random_subjects',
-  tags: '/arcadia/subjects_index',
+  tagsIndex: '/arcadia/subjects_index',
+  tags: '/arcadia/subjects',
   wordSearch: '/arcadia/word_search/',
   removeItem: '/arcadia/remove/',
   editItem: '/arcadia/update/',

--- a/src/dataSource/restApis/bindRestApi.ts
+++ b/src/dataSource/restApis/bindRestApi.ts
@@ -32,6 +32,7 @@ export const arcadiaApiEndpoints: ArcadiaEndpointsType = {
   randomTags: '/arcadia/random_subjects',
   tagsIndex: '/arcadia/subjects_index',
   tags: '/arcadia/subjects',
+  tagsWithCounts: '/arcadia/subjects_with_counts',
   wordSearch: '/arcadia/word_search/',
   removeItem: '/arcadia/remove/',
   editItem: '/arcadia/update/',

--- a/src/dataSource/types/apiTypes.ts
+++ b/src/dataSource/types/apiTypes.ts
@@ -50,8 +50,12 @@ export type ArcadiaEndpointsType = {
   addItem: string
 }
 
-export type ArcadiaTagsIndex = {
+export type BaseObjectOfStringArrays = {
   [key: string]: string[]
+}
+
+export type BaseObjectOfFunctions = {
+  [key: string]: Function
 }
 
 export type ArcadiaTags = {
@@ -68,7 +72,7 @@ export type ArcadiaSummaryApiResult = {
 }
 
 export type ArcadiaTagsApiResult = {
-  subjectIndex: ArcadiaTagsIndex
+  subjectIndex: BaseObjectOfStringArrays
 }
 
 export type LexiconSummaryApiResult = {

--- a/src/dataSource/types/apiTypes.ts
+++ b/src/dataSource/types/apiTypes.ts
@@ -42,6 +42,7 @@ export enum LexiconSearchType {
 export type ArcadiaEndpointsType = {
   summary: string,
   randomTags: string,
+  tagsIndex: string,
   tags: string,
   wordSearch: string,
   removeItem: string,
@@ -51,6 +52,11 @@ export type ArcadiaEndpointsType = {
 
 export type ArcadiaTagsIndex = {
   [key: string]: string[]
+}
+
+export type ArcadiaTags = {
+  numberOfSubjects: number,
+  subjects: string[],
 }
 
 export type ArcadiaSummaryApiResult = {

--- a/src/dataSource/types/apiTypes.ts
+++ b/src/dataSource/types/apiTypes.ts
@@ -44,6 +44,7 @@ export type ArcadiaEndpointsType = {
   randomTags: string,
   tagsIndex: string,
   tags: string,
+  tagsWithCounts: string,
   wordSearch: string,
   removeItem: string,
   editItem: string,
@@ -63,11 +64,20 @@ export type ArcadiaTags = {
   subjects: string[],
 }
 
+export type TagWithCount = {
+  tag: string,
+  count: number,
+}
+
+export type ArcadiaTagsWithCounts = {
+  numberOfSubjects: number,
+  subjectsCounts: TagWithCount[],
+}
+
 export type ArcadiaSummaryApiResult = {
   numberOfSubjects: number,
   numberOfUrlRecords: number,
   randomSubjectSample: string[],
-  subjects: string[],
   randomItemSample: ArcResultPackage
 }
 

--- a/src/hooks/useClickOutside.tsx
+++ b/src/hooks/useClickOutside.tsx
@@ -1,9 +1,8 @@
 import React, { useRef, useEffect } from 'react';
 
 export const useClickOutside = (handler: Function) => {
-  const ref = useRef(null);
-
-  const handleClickOutside = (event: { target: any }) => {
+  const ref: React.MutableRefObject<any> = useRef(null);
+  const handleClickOutside = (event: MouseEvent) => {
     if (ref.current && !ref.current.contains(event.target)) {
       handler();
     }

--- a/src/styles/themes/darkTheme.ts
+++ b/src/styles/themes/darkTheme.ts
@@ -75,6 +75,14 @@ export const DarkTheme: ThemeType = {
     transitionFontColor: '#252525',
     borderColor: '#484c58',
   },
+  input: {
+    autocompleteOptions: {
+      fontColor: '#FF9800',
+      backgroundColor: '#444e5c',
+      activeFontColor: '#000',
+      activeBackground: '#FF9800',
+    },
+  },
   header: {
     iconColor: '#dadada',
     iconHoverColor: customThemeDark.mainThemeColor,

--- a/src/styles/themes/darkTheme.ts
+++ b/src/styles/themes/darkTheme.ts
@@ -75,6 +75,11 @@ export const DarkTheme: ThemeType = {
     transitionFontColor: '#252525',
     borderColor: '#484c58',
   },
+  pill: {
+    circle: {
+      backgroundColor: '#9c9c9c',
+    },
+  },
   input: {
     autocompleteOptions: {
       fontColor: '#FF9800',

--- a/src/styles/themes/lightTheme.ts
+++ b/src/styles/themes/lightTheme.ts
@@ -55,6 +55,11 @@ export const LightTheme: ThemeType = {
     transitionFontColor: '#e9e9e9',
     borderColor: '#848585',
   },
+  pill: {
+    circle: {
+      backgroundColor: '#cfcfcf',
+    },
+  },
   input: {
     autocompleteOptions: {
       fontColor: '#A16000',

--- a/src/styles/themes/lightTheme.ts
+++ b/src/styles/themes/lightTheme.ts
@@ -55,6 +55,14 @@ export const LightTheme: ThemeType = {
     transitionFontColor: '#e9e9e9',
     borderColor: '#848585',
   },
+  input: {
+    autocompleteOptions: {
+      fontColor: '#A16000',
+      backgroundColor: '#dedede',
+      activeFontColor: '#FFF',
+      activeBackground: '#A16000',
+    },
+  },
   chart: {
     border: '#d1d1d1',
     axisLabelFontColor: '#565656',

--- a/src/types/themeTypes.ts
+++ b/src/types/themeTypes.ts
@@ -45,6 +45,15 @@ export type SubButtonStyleType = {
   borderColor: string,
 }
 
+export type InputStyleType = {
+  autocompleteOptions: {
+    fontColor: string,
+    backgroundColor: string,
+    activeFontColor: string,
+    activeBackground: string,
+  }
+}
+
 export type ChartStyleType = {
   border: string,
   axisLabelFontColor: string,
@@ -212,6 +221,7 @@ export type ThemeType = {
   throbber: ThrobberStyleType,
   button: ButtonStyleType,
   subButton: SubButtonStyleType,
+  input: InputStyleType,
   chart: ChartStyleType,
   header: HeaderStyleType,
   home: HomeThemeType,

--- a/src/types/themeTypes.ts
+++ b/src/types/themeTypes.ts
@@ -45,6 +45,12 @@ export type SubButtonStyleType = {
   borderColor: string,
 }
 
+export type PillStyleType = {
+  circle: {
+    backgroundColor: string,
+  }
+}
+
 export type InputStyleType = {
   autocompleteOptions: {
     fontColor: string,
@@ -221,6 +227,7 @@ export type ThemeType = {
   throbber: ThrobberStyleType,
   button: ButtonStyleType,
   subButton: SubButtonStyleType,
+  pill: PillStyleType,
   input: InputStyleType,
   chart: ChartStyleType,
   header: HeaderStyleType,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -49,20 +49,26 @@ export function acceptableCharactersTest(key: string):boolean {
 }
 
 export const appendStringBeforeFirstComma = (firstString: string, secondString: string): string => {
-  let lastCommaIndex = firstString.lastIndexOf(',');
+  const lastCommaIndex = firstString.lastIndexOf(',');
   if (lastCommaIndex !== -1) {
-      let substring = firstString.slice(0, lastCommaIndex+1);
-      return `${substring}${secondString},`;
-  } else {
-      return `${secondString},`;
+    const substring = firstString.slice(0, lastCommaIndex + 1);
+    return `${substring}${secondString},`;
   }
-}
+  return `${secondString},`;
+};
 
 export const stripBeforeLastComma = (inputString: string): string => {
-  let lastCommaIndex = inputString.lastIndexOf(',');
+  const lastCommaIndex = inputString.lastIndexOf(',');
   if (lastCommaIndex !== -1) {
-      return inputString.slice(lastCommaIndex + 1).trim();
-  } else {
-      return inputString;
+    return inputString.slice(lastCommaIndex + 1).trim();
+  }
+  return inputString;
+};
+
+export async function copyToClipboard(text: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    // do nothing for now
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -47,3 +47,22 @@ export function acceptableCharactersTest(key: string):boolean {
 
   return nonAcceptableKeys.indexOf(key) === -1;
 }
+
+export const appendStringBeforeFirstComma = (firstString: string, secondString: string): string => {
+  let lastCommaIndex = firstString.lastIndexOf(',');
+  if (lastCommaIndex !== -1) {
+      let substring = firstString.slice(0, lastCommaIndex+1);
+      return `${substring}${secondString},`;
+  } else {
+      return `${secondString},`;
+  }
+}
+
+export const stripBeforeLastComma = (inputString: string): string => {
+  let lastCommaIndex = inputString.lastIndexOf(',');
+  if (lastCommaIndex !== -1) {
+      return inputString.slice(lastCommaIndex + 1).trim();
+  } else {
+      return inputString;
+  }
+}

--- a/src/views/search/Search.tsx
+++ b/src/views/search/Search.tsx
@@ -11,6 +11,7 @@ import { AddSearchRecordButton } from '@/views/search/components/AddSearchRecord
 import { AddRecord } from '@/views/search/components/AddRecord/AddRecord';
 import { openInNewTab, quickSearchSystems } from '@/views/search/arcadia/utils';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import SearchProvider from '@/context/searchContext';
 import { SearchMainContainer, SearchRefContainer, SearchMenuContainer } from './styles/searchStyles';
 
 export function Search() {
@@ -84,18 +85,20 @@ export function Search() {
   ];
 
   return (
-    <SearchMainContainer>
-      <SearchRefContainer ref={ref}>
-        <SearchMenuContainer>
-          <SearchBar searchSystem={arcadiaSys} />
-          <AddSearchRecordButton activateAction={activateAddRecordFormView} />
-        </SearchMenuContainer>
-        <AddRecord
-          isAddRecordViewable={isAddRecordViewable}
-          cancelAddRecordFormView={hideAddRecordFormView}
-        />
-      </SearchRefContainer>
-      <RoutesGenerator routerRoutesConfig={routerConfig} />
-    </SearchMainContainer>
+    <SearchProvider>
+      <SearchMainContainer>
+        <SearchRefContainer ref={ref}>
+          <SearchMenuContainer>
+            <SearchBar searchSystem={arcadiaSys} />
+            <AddSearchRecordButton activateAction={activateAddRecordFormView} />
+          </SearchMenuContainer>
+          <AddRecord
+            isAddRecordViewable={isAddRecordViewable}
+            cancelAddRecordFormView={hideAddRecordFormView}
+          />
+        </SearchRefContainer>
+        <RoutesGenerator routerRoutesConfig={routerConfig} />
+      </SearchMainContainer>
+    </SearchProvider>
   );
 }

--- a/src/views/search/arcadia/Arcadia.tsx
+++ b/src/views/search/arcadia/Arcadia.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ArcadiaProps, ArcadiaView } from '@/views/search/types/searchTypes';
-import ArcadiaSearchHome from '@/views/search/arcadia/components/ArcadiaSearchHome';
+import { ArcadiaSearchHome } from '@/views/search/arcadia/components/ArcadiaSearchHome';
 import { ArcadiaTagIndex } from '@/views/search/arcadia/components/ArcadiaTagIndex/ArcadiaTagIndex';
 import { ArcadiaContainer } from './styles/arcadiaStyles';
 
@@ -12,12 +12,7 @@ export function Arcadia(props: ArcadiaProps) {
   if (view === ArcadiaView.INDEX) {
     viewBody = <ArcadiaTagIndex searchTerm={searchTerm} navigate={navLocation} />;
   } else {
-    viewBody = (
-      <ArcadiaSearchHome
-        tagSearchTerm={searchTerm}
-        navigate={navLocation}
-      />
-    );
+    viewBody = <ArcadiaSearchHome navigate={navLocation} />;
   }
 
   return (

--- a/src/views/search/arcadia/components/ArcResult/ArcResult.tsx
+++ b/src/views/search/arcadia/components/ArcResult/ArcResult.tsx
@@ -26,6 +26,7 @@ export function ArcResult(props: ArcResultProps) {
   const invalidateArcQueries = () => {
     queryClient.invalidateQueries(arcadiaApiEndpoints.summary);
     queryClient.invalidateQueries('arcadiaWordSearch');
+    // TODO: Figure out how to reload (arcadiaApiEndpoints.tagsWithCounts) query into context
   };
 
   const { ref: deleteRef } = useClickOutside(() => {

--- a/src/views/search/arcadia/components/ArcResult/ArcResult.tsx
+++ b/src/views/search/arcadia/components/ArcResult/ArcResult.tsx
@@ -41,9 +41,7 @@ export function ArcResult(props: ArcResultProps) {
         { deep: true },
       );
 
-      if (state.tags.length !== camelCasedData.numberOfSubjects) {
-        dispatch({ type: SearchActionsEnum.LOAD_TAGS, value: camelCasedData.subjectsCounts });
-      }
+      dispatch({ type: SearchActionsEnum.LOAD_TAGS, value: camelCasedData.subjectsCounts });
     });
   };
 

--- a/src/views/search/arcadia/components/ArcResult/components/ArcResultEdit/ArcResultEditConfirm.tsx
+++ b/src/views/search/arcadia/components/ArcResult/components/ArcResultEdit/ArcResultEditConfirm.tsx
@@ -22,7 +22,6 @@ export function ArcResultEditConfirm(props: ArcResultEditConfirmProps) {
   if (!isFetching) {
     if (isError && error) {
       editResult.editingMessage = `An error has occurred editing: ${itemEditPackage.data}`;
-      onEditConfirmed(editResult);
     } else if (data) {
       const arcDeleteResult: ArcEditItemResults = camelcaseKeys<ArcEditItemResults>(
         data,
@@ -34,8 +33,9 @@ export function ArcResultEditConfirm(props: ArcResultEditConfirmProps) {
       } else {
         editResult.editingMessage = 'There was an issue with editing this record';
       }
-      onEditConfirmed(editResult);
     }
+    // TODO: Rid ourselves of the dependence on JS call stack manipulation here
+    setTimeout(() => onEditConfirmed(editResult), 0);
   }
 
   return (

--- a/src/views/search/arcadia/components/ArcResult/components/ArcResultEdit/ArcResultEditForm.tsx
+++ b/src/views/search/arcadia/components/ArcResult/components/ArcResultEdit/ArcResultEditForm.tsx
@@ -12,10 +12,13 @@ import {
   ArcResultDisplay,
   ArcResultEditViewProps,
 } from '@/views/search/arcadia/types/arcadiaTypes';
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useContext, FormEventHandler } from 'react';
 import { FocusableButton } from '@/components/Nav/Button';
+import MultiTextInputWithAutocomplete from '@/components/Input/MultiTextInputWithAutocomplete';
+import { SearchContext } from '@/context/searchContext';
 
 export function ArcResultEditForm(props: ArcResultEditViewProps) {
+  const { state } = useContext(SearchContext);
   const { itemKey, tags, title, description, image, onReset, onEdit } = props;
   const imageInputRef: React.MutableRefObject<any> = useRef();
   const urlInputRef: React.MutableRefObject<any> = useRef();
@@ -28,10 +31,14 @@ export function ArcResultEditForm(props: ArcResultEditViewProps) {
   }, []);
 
   const editItem = () => {
+    const tagsFromInput: string = tagsInputRef.current.value.endsWith(',')
+      ? tagsInputRef.current.value.substring(0, tagsInputRef.current.value.length - 1)
+      : tagsInputRef.current.value;
+
     const editItemPackage: ArcEditPackage = {
       data: itemKey,
       dataUpdate: urlInputRef.current.value,
-      tags: String(tagsInputRef.current.value).replace(/\s+/g, '').split(','),
+      tags: String(tagsFromInput).replace(/\s+/g, '').split(','),
       title: titleInputRef.current.value,
       description: descriptionInputRef.current.value,
       image: imageInputRef.current.value,
@@ -43,7 +50,7 @@ export function ArcResultEditForm(props: ArcResultEditViewProps) {
     onReset(ArcResultDisplay.VIEW);
   };
 
-  const handleSubmit = (e: { preventDefault: () => void; }): void => {
+  const handleSubmit: FormEventHandler = (e): void => {
     e.preventDefault();
     editItem();
   };
@@ -70,15 +77,13 @@ export function ArcResultEditForm(props: ArcResultEditViewProps) {
               ref={urlInputRef}
             />
           </div>
-          <div style={{ marginTop: '10px' }}>
-            <ArcInputTitle>Tags (comma separated)</ArcInputTitle>
-            <ArcInput
-              title="Tags Edit"
-              type="text"
-              defaultValue={tags}
-              ref={tagsInputRef}
-            />
-          </div>
+          <MultiTextInputWithAutocomplete
+            label="Tags (comma separated)"
+            title="Tags Edit"
+            defaultValue={tags}
+            autocompleteOptions={state.tags}
+            inputRef={tagsInputRef}
+          />
         </ArcEditFieldContainer>
         <ArcEditFieldContainer>
           <div>

--- a/src/views/search/arcadia/components/ArcResult/components/ArcResultView.tsx
+++ b/src/views/search/arcadia/components/ArcResult/components/ArcResultView.tsx
@@ -44,8 +44,8 @@ export function ArcResultView(props: ArcResultViewProps) {
     : <div />;
 
   const tagsView = tags ? tags.map((tag: string) => (
-    <Link to={navigate.concat(tag)}>
-      <Pill key={'resultTagListItem'.concat(tag)}>
+    <Link key={'resultTagListItem'.concat(tag)} to={navigate.concat(tag)}>
+      <Pill>
         {tag}
       </Pill>
     </Link>

--- a/src/views/search/arcadia/components/ArcResult/components/ArcResultView.tsx
+++ b/src/views/search/arcadia/components/ArcResult/components/ArcResultView.tsx
@@ -20,7 +20,9 @@ import { ArcResultViewProps, ArcResultDisplay } from '@/views/search/arcadia/typ
 import { Pill, PillContainer } from '@/views/styles/appStyles';
 import { Button } from '@/components/Nav/Button';
 import { BsFillImageFill } from 'react-icons/bs';
+import { BiCopy } from 'react-icons/bi';
 import { ImageWithPlaceHolder } from '@/components/Images/ImageWithPlaceHolder';
+import { copyToClipboard } from '@/utils/utils';
 
 export function ArcResultView(props: ArcResultViewProps) {
   const { _ref, arcResultPackage, onEdit, onDelete, navigate, displayMessage } = props;
@@ -74,6 +76,17 @@ export function ArcResultView(props: ArcResultViewProps) {
           </span>
           <span>
             <span style={{ display: 'flex' }}>
+              <Button
+                fontSize="12px"
+                letterSpacing="2px"
+                padding="2px 8px 0 8px"
+                margin="3px"
+                borderRadius="5px"
+                onClick={() => copyToClipboard(data)}
+                title="Copy Link"
+              >
+                <BiCopy />
+              </Button>
               <Button
                 fontSize="12px"
                 letterSpacing="2px"

--- a/src/views/search/arcadia/components/ArcResult/components/ArcResultView.tsx
+++ b/src/views/search/arcadia/components/ArcResult/components/ArcResultView.tsx
@@ -39,6 +39,7 @@ export function ArcResultView(props: ArcResultViewProps) {
         src={imageUrlCompletion(data, image)}
         alt="img"
         placeHolderImage={<BsFillImageFill style={{ fontSize: '60px' }} />}
+        lazyLoad
       />
     )
     : <div />;

--- a/src/views/search/arcadia/components/ArcResultSubNode.tsx
+++ b/src/views/search/arcadia/components/ArcResultSubNode.tsx
@@ -1,23 +1,26 @@
 import {
   ArcResultOuterContainer,
+  SubTagCount,
   SubTagHeader,
   SubTagHeaderContainer,
 } from '@/views/search/arcadia/styles/arcadiaStyles';
 import { ArcResult } from '@/views/search/arcadia/components/ArcResult/ArcResult';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { ArcResultSubNodeProps } from '@/views/search/arcadia/types/arcadiaTypes';
+import { SearchContext } from '@/context/searchContext';
 
 export function ArcResultSubNode(props: ArcResultSubNodeProps) {
   const { node, navigate } = props;
+  const tagsCountHashMap: Map<string, number> = useContext(SearchContext).state.tagsHashMap;
+
   return (
     <div>
       <SubTagHeaderContainer>
-        <Link to={navigate.concat(node.subject)}>
-          <SubTagHeader
-            id={'SubTagHeader-'.concat(node.subject)}
-          >
-            {node.subject}
+        <Link style={{ width: '100%' }} to={navigate.concat(node.subject)}>
+          <SubTagHeader id={'SubTagHeader-'.concat(node.subject)}>
+            <span>{node.subject}</span>
+            <SubTagCount> {tagsCountHashMap.get(node.subject)}</SubTagCount>
           </SubTagHeader>
         </Link>
       </SubTagHeaderContainer>

--- a/src/views/search/arcadia/components/ArcSearchPageInnerLinks.tsx
+++ b/src/views/search/arcadia/components/ArcSearchPageInnerLinks.tsx
@@ -8,9 +8,8 @@ export function ArcSearchPageInnerLinks(props: ArcSearchPageInnerLinksProps) {
     <InnerLinks>
       {
         tags.map((tag: string) => (
-          <a href={'#SubTagHeader-'.concat(tag)}>
+          <a key={'tagInnerLink'.concat(tag)}  href={'#SubTagHeader-'.concat(tag)}>
             <SubTagHeader
-              key={'tagInnerLink'.concat(tag)}
               style={{ minWidth: 'auto', width: 'auto', fontSize: '16px' }}
             >
               {tag}

--- a/src/views/search/arcadia/components/ArcadiaSearch.tsx
+++ b/src/views/search/arcadia/components/ArcadiaSearch.tsx
@@ -17,9 +17,7 @@ import { organizeNodes } from '@/views/search/arcadia/utils';
 import { ArcSearchPageInnerLinks } from '@/views/search/arcadia/components/ArcSearchPageInnerLinks';
 import { ArcSearchPageHeader } from '@/views/search/arcadia/components/ArcSearchPageHeader';
 import { useQuery, UseQueryResult } from 'react-query';
-import {
-  ArcadiaTags,
-} from '@/dataSource/types/apiTypes';
+import { ArcadiaTagsWithCounts } from '@/dataSource/types/apiTypes';
 import { arcadiaApiEndpoints } from '@/dataSource/restApis/bindRestApi';
 import { SearchContext } from '@/context/searchContext';
 import { SearchActionsEnum } from '@/context/types/enums';
@@ -31,27 +29,29 @@ export function ArcadiaSearch() {
   const searchWord: string = searchParams.get('word');
   const navLocation: string = '/search/system/arcadia/data?word=';
   const { data, isLoading, isError } = useArcadiaWordSearch(searchWord);
-  const arcadiaSubjects: UseQueryResult<ArcadiaTags> = useQuery<ArcadiaTags,
-    Error>(arcadiaApiEndpoints.tags);
+  const arcadiaSubjectsWithCounts: UseQueryResult<ArcadiaTagsWithCounts> = useQuery<
+    ArcadiaTagsWithCounts, Error>(arcadiaApiEndpoints.tagsWithCounts);
 
-  if (isLoading || arcadiaSubjects.isLoading) {
+  if (isLoading || arcadiaSubjectsWithCounts.isLoading) {
     return (<Loader />);
   }
 
-  if (isError || arcadiaSubjects.isError) {
+  if (isError || arcadiaSubjectsWithCounts.isError) {
     const message: string = 'Error has occurred getting search data or subjects';
     return (<ErrorViewDefault errorMessage={message} />);
   }
 
-  const arcadiaSubjectsResponse: ArcadiaTags = camelcaseKeys<ArcadiaTags>(
-    arcadiaSubjects.data,
+  const arcadiaSubjectsResponse: ArcadiaTagsWithCounts = camelcaseKeys<ArcadiaTagsWithCounts>(
+    arcadiaSubjectsWithCounts.data,
     { deep: true },
   );
 
   // TODO: Update this to not use a setTimeout
   if (state.tags.length !== arcadiaSubjectsResponse.numberOfSubjects) {
     setTimeout(() => {
-      dispatch({ type: SearchActionsEnum.LOAD_TAGS, value: arcadiaSubjectsResponse.subjects });
+      dispatch(
+        { type: SearchActionsEnum.LOAD_TAGS, value: arcadiaSubjectsResponse.subjectsCounts },
+      );
     }, 0);
   }
 

--- a/src/views/search/arcadia/components/ArcadiaSearchHome.tsx
+++ b/src/views/search/arcadia/components/ArcadiaSearchHome.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useQuery, UseQueryResult } from 'react-query';
 import Loader from '@/components/Misc/Loader';
 import camelcaseKeys from 'camelcase-keys';
@@ -19,9 +19,12 @@ import { searchTags } from '@/views/search/arcadia/utils';
 import { ArcadiaGraphCoherence } from '@/views/search/arcadia/components/ArcadiaGraphCoherence';
 import { LexiconDictionarySize } from '@/views/search/lexicon/components/LexiconDictionarySize';
 import { ArcRandomRecord } from '@/views/search/arcadia/components/ArcRandomRecord';
+import { SearchContext } from '@/context/searchContext';
+import { SearchActionsEnum } from '@/context/types/enums';
 
 function ArcadiaSearchHome(props: ArcadiaSearchHomeProps) {
   const { tagSearchTerm, navigate } = props;
+  const { state, dispatch } = useContext(SearchContext);
   const lexiconSummary: UseQueryResult<LexiconSummaryApiResult> = useQuery<LexiconSummaryApiResult,
     Error>(lexiconApiEndpoints.summary);
   const arcadiaSummary: UseQueryResult<ArcadiaSummaryApiResult> = useQuery<ArcadiaSummaryApiResult,
@@ -54,6 +57,13 @@ function ArcadiaSearchHome(props: ArcadiaSearchHomeProps) {
   let relevantTags: string[];
   let tagGroupTitle: string;
   let highlightTags: boolean = false;
+
+  // TODO: Update this to not use a setTimeout
+  if (state.tags.length !== arcadiaSummaryResponse.subjects.length) {
+    setTimeout(() => {
+      dispatch({ type: SearchActionsEnum.LOAD_TAGS, value: arcadiaSummaryResponse.subjects });
+    }, 0);
+  }
 
   if (isSearch) {
     relevantTags = searchTags(tagSearchTerm, arcadiaSummaryResponse.subjects);

--- a/src/views/search/arcadia/components/ArcadiaSearchHome.tsx
+++ b/src/views/search/arcadia/components/ArcadiaSearchHome.tsx
@@ -15,15 +15,14 @@ import {
 import { ArcadiaSearchHomeProps } from '@/views/search/arcadia/types/arcadiaTypes';
 import LexiconCard from '@/views/search/lexicon/components/lexiconCard/LexiconCard';
 import TagGroup from '@/views/search/arcadia/components/TagGroup';
-import { searchTags } from '@/views/search/arcadia/utils';
 import { ArcadiaGraphCoherence } from '@/views/search/arcadia/components/ArcadiaGraphCoherence';
 import { LexiconDictionarySize } from '@/views/search/lexicon/components/LexiconDictionarySize';
 import { ArcRandomRecord } from '@/views/search/arcadia/components/ArcRandomRecord';
 import { SearchContext } from '@/context/searchContext';
 import { SearchActionsEnum } from '@/context/types/enums';
 
-function ArcadiaSearchHome(props: ArcadiaSearchHomeProps) {
-  const { tagSearchTerm, navigate } = props;
+export function ArcadiaSearchHome(props: ArcadiaSearchHomeProps) {
+  const { navigate } = props;
   const { state, dispatch } = useContext(SearchContext);
   const lexiconSummary: UseQueryResult<LexiconSummaryApiResult> = useQuery<LexiconSummaryApiResult,
     Error>(lexiconApiEndpoints.summary);
@@ -53,25 +52,15 @@ function ArcadiaSearchHome(props: ArcadiaSearchHomeProps) {
     { deep: true },
   );
 
-  const isSearch: boolean = tagSearchTerm.length > 0;
-  let relevantTags: string[];
-  let tagGroupTitle: string;
-  let highlightTags: boolean = false;
+  const relevantTags: string[] = arcadiaSummaryResponse.randomSubjectSample;
+  const tagGroupTitle: string = 'Interesting Tags';
+  const highlightTags: boolean = false;
 
   // TODO: Update this to not use a setTimeout
   if (state.tags.length !== arcadiaSummaryResponse.subjects.length) {
     setTimeout(() => {
       dispatch({ type: SearchActionsEnum.LOAD_TAGS, value: arcadiaSummaryResponse.subjects });
     }, 0);
-  }
-
-  if (isSearch) {
-    relevantTags = searchTags(tagSearchTerm, arcadiaSummaryResponse.subjects);
-    tagGroupTitle = `Tag Search (${relevantTags.length})`;
-    highlightTags = true;
-  } else {
-    relevantTags = arcadiaSummaryResponse.randomSubjectSample;
-    tagGroupTitle = 'Interesting Tags';
   }
 
   return (
@@ -104,9 +93,3 @@ function ArcadiaSearchHome(props: ArcadiaSearchHomeProps) {
     </>
   );
 }
-
-ArcadiaSearchHome.defaultProps = {
-  tagSearchTerm: '',
-};
-
-export default ArcadiaSearchHome;

--- a/src/views/search/arcadia/components/ArcadiaTagIndex/ArcadiaTagIndex.tsx
+++ b/src/views/search/arcadia/components/ArcadiaTagIndex/ArcadiaTagIndex.tsx
@@ -14,7 +14,7 @@ import camelcaseKeys from 'camelcase-keys';
 export function ArcadiaTagIndex(props: ArcadiaTagIndexProps) {
   const { searchTerm, navigate } = props;
   const arcadiaTagsHook: UseQueryResult<ArcadiaTagsApiResult> = useQuery<ArcadiaTagsApiResult,
-    Error>(arcadiaApiEndpoints.tags);
+    Error>(arcadiaApiEndpoints.tagsIndex);
 
   if (arcadiaTagsHook.isLoading) {
     return <Loader />;

--- a/src/views/search/arcadia/components/TagGroup.tsx
+++ b/src/views/search/arcadia/components/TagGroup.tsx
@@ -1,25 +1,38 @@
 import {
   AlphabetHeader,
   TagsSection,
-  SubTagHeader,
+  SubTagHeader, SubTagCount,
 } from '@/views/search/arcadia/styles/arcadiaStyles';
 import {
   LatestTagsListContainer,
   TagGroupSection,
 } from '@/views/search/styles/searchStyles';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { TagGroupProps } from '@/views/search/arcadia/types/arcadiaTypes';
+import { SearchContext } from '@/context/searchContext';
+import { TagWithCount } from '@/dataSource/types/apiTypes';
+
+// TODO: Extract the context and feed in as a prop, also find a way to supply this data straight
+//  from the DB to reduce formatting processing in the UI
 
 function TagGroup(props: TagGroupProps) {
   const { title, tagList, navigate, highlight } = props;
+  const tagsCountHashMap: Map<string, number> = useContext(SearchContext).state.tagsHashMap;
+  const tagsWithCount: TagWithCount[] = tagList.map((tag: string) => ({
+    tag,
+    count: tagsCountHashMap.get(tag),
+  })).slice(0, 18);
+
+  tagsWithCount.sort((a, b) => (a.count < b.count ? 1 : -1));
+
   let viewBody: JSX.Element;
   if (tagList && tagList.length > 0) {
     viewBody = (
       <>
         {
-          tagList.map((tag: string) => (
-            <Link key={'tagListItem'.concat(tag)} to={navigate.concat(tag)}>
+          tagsWithCount.map((tagWithCount: TagWithCount) => (
+            <Link key={'tagListItem'.concat(tagWithCount.tag)} to={navigate.concat(tagWithCount.tag)}>
               <SubTagHeader
                 style={{
                   minWidth: 'auto',
@@ -27,7 +40,8 @@ function TagGroup(props: TagGroupProps) {
                   boxShadow: 'none',
                 }}
               >
-                {tag}
+                <span>{tagWithCount.tag}</span>
+                <SubTagCount> {tagWithCount.count}</SubTagCount>
               </SubTagHeader>
             </Link>
           ))

--- a/src/views/search/arcadia/components/TagGroup.tsx
+++ b/src/views/search/arcadia/components/TagGroup.tsx
@@ -21,8 +21,8 @@ function TagGroup(props: TagGroupProps) {
   const tagsCountHashMap: Map<string, number> = useContext(SearchContext).state.tagsHashMap;
   const tagsWithCount: TagWithCount[] = tagList.map((tag: string) => ({
     tag,
-    count: tagsCountHashMap.get(tag),
-  })).slice(0, 18);
+    count: tagsCountHashMap.get(tag) || 0,
+  })).slice(0, 20);
 
   tagsWithCount.sort((a, b) => (a.count < b.count ? 1 : -1));
 

--- a/src/views/search/arcadia/components/TagGroup.tsx
+++ b/src/views/search/arcadia/components/TagGroup.tsx
@@ -19,9 +19,8 @@ function TagGroup(props: TagGroupProps) {
       <>
         {
           tagList.map((tag: string) => (
-            <Link to={navigate.concat(tag)}>
+            <Link key={'tagListItem'.concat(tag)} to={navigate.concat(tag)}>
               <SubTagHeader
-                key={'tagListItem'.concat(tag)}
                 style={{
                   minWidth: 'auto',
                   width: 'auto',

--- a/src/views/search/arcadia/styles/arcadiaStyles.ts
+++ b/src/views/search/arcadia/styles/arcadiaStyles.ts
@@ -260,6 +260,16 @@ export const AutoCompleteContainer = styled.ul<{ show: boolean }>`
   li {
     list-style: none;
     padding: 5px;
+    display: flex;
+    justify-content: space-between;
+
+    .left {
+      margin-left: 3px;
+    }
+
+    .right {
+      margin-right: 5px;
+    }
   }
 
   .active{

--- a/src/views/search/arcadia/styles/arcadiaStyles.ts
+++ b/src/views/search/arcadia/styles/arcadiaStyles.ts
@@ -47,6 +47,7 @@ export const SubTagHeader = styled(NonListHoverable)`
   font-size: 17px;
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06) ,0 2px 2px rgba(0,0,0,0.04) ,0 4px 4px rgba(0,0,0,0.05) ,0 6px 6px rgba(0,0,0,0.06);
   display: flex;
+  justify-content: space-between;
 `;
 
 export const SubTagCount = styled.span`

--- a/src/views/search/arcadia/styles/arcadiaStyles.ts
+++ b/src/views/search/arcadia/styles/arcadiaStyles.ts
@@ -171,6 +171,7 @@ export const ArcEditThrobberContainer = styled(ArcAddThrobberContainer)`
 export const ArcAddInputContainer = styled.div`
   margin-top: 10px;
   flex-grow: 1;
+  position: relative;
 `;
 
 export const ArcResultTextContainer = styled.div`
@@ -238,6 +239,35 @@ export const ArcInput = styled(Input)`
   }
 
   @media ${device.tabletS} {}
+`;
+
+export const AutoCompleteContainer = styled.ul<{ show: boolean }>`
+  display: ${(props) => (props.show ? 'block' : 'none')};
+  width: calc(100% - 12px);
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  border: 2px solid #696969;
+  border-top: 0;
+  background-color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.backgroundColor};
+  color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.fontColor};
+  font-size: 16px;
+  position: absolute;
+  padding: 10px 3px;
+  margin: -3px 0;
+  max-height: 225px;
+  overflow-y: scroll;
+
+  li {
+    list-style: none;
+    padding: 5px;
+  }
+
+  .active{
+    background-color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.activeBackground};
+    color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.activeFontColor
+};
+    border-radius: 3px;
+  }
 `;
 
 export const ArcInputTextArea = styled(InputTextArea)`

--- a/src/views/search/arcadia/styles/arcadiaStyles.ts
+++ b/src/views/search/arcadia/styles/arcadiaStyles.ts
@@ -46,6 +46,20 @@ export const SubTagHeader = styled(NonListHoverable)`
   border-radius: 5px;
   font-size: 17px;
   box-shadow: 0 0 0 1px rgba(0,0,0,0.06) ,0 2px 2px rgba(0,0,0,0.04) ,0 4px 4px rgba(0,0,0,0.05) ,0 6px 6px rgba(0,0,0,0.06);
+  display: flex;
+`;
+
+export const SubTagCount = styled.span`
+  background-color: ${(props: GlobalThemeType) => props.theme.pill.circle.backgroundColor};
+  color: #010101;
+  border-radius: 50%;
+  height: 20px;
+  width: 20px;
+  font-style: unset;
+  display: inline-block;
+  text-align: center;
+  margin: 3px 0 0 5px;
+  font-size: 13px;
 `;
 
 export const SubTagHeaderContainer = styled.div`

--- a/src/views/search/arcadia/types/arcadiaTypes.ts
+++ b/src/views/search/arcadia/types/arcadiaTypes.ts
@@ -150,7 +150,6 @@ export type ArcSearchPageHeaderProps = {
 }
 
 export type ArcadiaSearchHomeProps = {
-  tagSearchTerm ?: string
   navigate: string
 }
 

--- a/src/views/search/arcadia/utils.ts
+++ b/src/views/search/arcadia/utils.ts
@@ -3,6 +3,7 @@ import {
   ArcSearchResultPackage,
   ArcSearchResultsNode,
 } from '@/views/search/arcadia/types/arcadiaTypes';
+import { BaseObjectOfFunctions } from '@/dataSource/types/apiTypes';
 
 export function dictionarySearchTermValidator(term: string) {
   return (term.indexOf('_') < 0 && term.match(/^[a-zA-Z]+$/));
@@ -54,7 +55,7 @@ export function openInNewTab(url: string) {
   window.open(url, '_blank').focus();
 }
 
-export const quickSearchSystems: {[key: string]: Function} = {
+export const quickSearchSystems: BaseObjectOfFunctions = {
   ph(searchTerm: string) {
     return `https://www.phind.com/search?q=${searchTerm}&source=searchbox`;
   },

--- a/src/views/search/components/AddRecord/AddRecord.tsx
+++ b/src/views/search/components/AddRecord/AddRecord.tsx
@@ -8,6 +8,9 @@ import { SearchAddRecordContainer } from '@/views/search/styles/searchStyles';
 import { ArcAddContainer, ArcChangeStatusContainer } from '@/views/search/arcadia/styles/arcadiaStyles';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { arcadiaApiEndpoints } from '@/dataSource/restApis/bindRestApi';
+import { SearchActionsEnum } from '@/context/types/enums';
+import { ArcadiaTagsWithCounts } from '@/dataSource/types/apiTypes';
+import camelcaseKeys from 'camelcase-keys';
 
 export function AddRecord(props: AddRecordProps) {
   const { isAddRecordViewable, cancelAddRecordFormView } = props;
@@ -38,6 +41,7 @@ export function AddRecord(props: AddRecordProps) {
 
     queryClient.invalidateQueries('arcadiaWordSearch');
     queryClient.invalidateQueries(arcadiaApiEndpoints.summary);
+    // TODO: Figure out how to reload (arcadiaApiEndpoints.tagsWithCounts) query into context
   };
 
   let body: JSX.Element;

--- a/src/views/search/components/AddRecord/AddRecord.tsx
+++ b/src/views/search/components/AddRecord/AddRecord.tsx
@@ -53,9 +53,7 @@ export function AddRecord(props: AddRecordProps) {
         { deep: true },
       );
 
-      if (state.tags.length !== camelCasedData.numberOfSubjects) {
-        dispatch({ type: SearchActionsEnum.LOAD_TAGS, value: camelCasedData.subjectsCounts });
-      }
+      dispatch({ type: SearchActionsEnum.LOAD_TAGS, value: camelCasedData.subjectsCounts });
     });
   };
 

--- a/src/views/search/components/AddRecord/AddRecordForm/AddRecordForm.tsx
+++ b/src/views/search/components/AddRecord/AddRecordForm/AddRecordForm.tsx
@@ -1,12 +1,18 @@
 import {
-  ArcRecordFormContainer, ArcAddFieldContainer, ArcAddInputContainer,
-  ArcInput, ArcInputTitle,
+  ArcRecordFormContainer,
+  ArcAddFieldContainer,
+  ArcAddInputContainer,
+  ArcInput,
+  ArcInputTitle,
 } from '@/views/search/arcadia/styles/arcadiaStyles';
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useContext, FormEventHandler } from 'react';
 import { Button } from '@/components/Nav/Button';
 import { AddRecordFormProps, ArcAddPackage } from '@/views/search/types/searchTypes';
+import { SearchContext } from '@/context/searchContext';
+import MultiTextInputWithAutocomplete from '@/components/Input/MultiTextInputWithAutocomplete';
 
 export function AddRecordForm(props: AddRecordFormProps) {
+  const { state } = useContext(SearchContext);
   const { _ref, cancelAddForm, onAddItem, isFormActive, isSuccess } = props;
   const urlInputRef: React.MutableRefObject<any> = useRef();
   const tagsInputRef: React.MutableRefObject<any> = useRef();
@@ -20,15 +26,19 @@ export function AddRecordForm(props: AddRecordFormProps) {
 
   const addItem = () => {
     if (urlInputRef.current.value !== '') {
+      const tagsFromInput: string = tagsInputRef.current.value.endsWith(',')
+        ? tagsInputRef.current.value.substring(0, tagsInputRef.current.value.length - 1)
+        : tagsInputRef.current.value;
+
       const addItemPackage: ArcAddPackage = {
         data: urlInputRef.current.value,
-        tags: String(tagsInputRef.current.value).replace(/\s+/g, '').split(','),
+        tags: String(tagsFromInput).replace(/\s+/g, '').split(','),
       };
       onAddItem(addItemPackage);
     }
   };
 
-  const handleSubmit = (e: { preventDefault: () => void; }): void => {
+  const handleSubmit: FormEventHandler = (e) => {
     e.preventDefault();
     addItem();
   };
@@ -45,15 +55,13 @@ export function AddRecordForm(props: AddRecordFormProps) {
             disabled={!isFormActive}
           />
         </ArcAddInputContainer>
-        <ArcAddInputContainer>
-          <ArcInputTitle>Tags (comma separated)</ArcInputTitle>
-          <ArcInput
-            title="Tags Edit"
-            type="text"
-            ref={tagsInputRef}
-            disabled={!isFormActive}
-          />
-        </ArcAddInputContainer>
+        <MultiTextInputWithAutocomplete
+          label="Tags (comma separated)"
+          title="Tags Edit"
+          isInputActive={isFormActive}
+          autocompleteOptions={state.tags}
+          inputRef={tagsInputRef}
+        />
       </ArcAddFieldContainer>
       <ArcAddFieldContainer style={{ marginTop: '20px', justifyContent: 'end' }}>
         <div>

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -9,7 +9,6 @@ import React, {
 import { IStringIndexedObject, SearchBarProps } from '@/views/search/types/searchTypes';
 import {
   acceptableCharactersTest,
-  stripBeforeLastComma,
 } from '@/utils/utils';
 import { IoMdClose } from 'react-icons/io';
 import { useWh00tWebsocket } from '@/context/wh00tContext';
@@ -47,7 +46,7 @@ export function SearchBar(props: SearchBarProps) {
     if (inputValue !== '') {
       const MAX_OPTIONS: number = 50;
       const filteredOptions: TagWithCount[] = searchContext.tags.filter((item) => item.tag.includes(
-        stripBeforeLastComma(inputValue),
+        inputValue,
       )).slice(0, MAX_OPTIONS);
 
       if (filteredOptions.length > 0) {
@@ -58,7 +57,6 @@ export function SearchBar(props: SearchBarProps) {
       }
     } else {
       setShowAutoCompleteOptions(false);
-      setHasSearchTerm(false);
     }
   }, [inputValue]);
 
@@ -78,9 +76,9 @@ export function SearchBar(props: SearchBarProps) {
     }
   };
 
-  const onInputKeydown: KeyboardEventHandler = (e) => {
+  const onInputKeyUp: KeyboardEventHandler = (e) => {
     const specialKeys: string[] = ['ArrowUp', 'ArrowDown', 'Enter', 'Escape'];
-    setHasSearchTerm(Boolean(searchInputRef.current.value));
+    setHasSearchTerm(searchInputRef.current.value !== '');
 
     if (specialKeys.includes(e.key)) {
       if (e.key === 'ArrowUp') {
@@ -123,7 +121,7 @@ export function SearchBar(props: SearchBarProps) {
 
   const addToInputOnclick = (index: number) => {
     addToInput(listValues[index].tag);
-    searchInputRef.current.focus();
+    setTimeout(() => searchInputRef.current.focus(), 0);
   };
 
   const addToListItemRefs = (index: number, e: HTMLLIElement) => {
@@ -157,7 +155,7 @@ export function SearchBar(props: SearchBarProps) {
           type="text"
           placeholder="Search Term"
           ref={searchInputRef}
-          onKeyDown={onInputKeydown}
+          onKeyUp={onInputKeyUp}
           onChange={onInputChange}
           autoFocus
           hasSearchTerm={hasSearchTerm}

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -89,14 +89,10 @@ export function SearchBar(props: SearchBarProps) {
         e.preventDefault();
         setActiveItemIndex((prevIndex) => Math.min(prevIndex + 1, listValues.length - 1));
       } else if (e.key === 'Enter') {
-        if (showAutoCompleteOptions && activeItemIndex !== inactiveItemsIndex) {
-          e.preventDefault();
-          setShowAutoCompleteOptions(false);
-          addToInput(listValues[activeItemIndex].tag);
-        } else {
-          setShowAutoCompleteOptions(false);
-          sendSearchWord();
-        }
+        e.preventDefault();
+        setShowAutoCompleteOptions(false);
+        addToInput(listValues[activeItemIndex].tag);
+        sendSearchWord();
       } else if (e.key === 'Escape') {
         e.preventDefault();
         setShowAutoCompleteOptions(false);
@@ -120,8 +116,10 @@ export function SearchBar(props: SearchBarProps) {
     searchInputRef.current.focus();
   };
 
-  const addToInputOnclick = (index: number) => {
-    addToInput(listValues[index].tag);
+  const takeActionOnclick = (index: number) => {
+    setShowAutoCompleteOptions(false);
+    addToInput(listValues[activeItemIndex].tag);
+    sendSearchWord();
     setTimeout(() => searchInputRef.current.focus(), 0);
   };
 
@@ -139,7 +137,7 @@ export function SearchBar(props: SearchBarProps) {
         key={item.tag}
         ref={(e: HTMLLIElement) => (addToListItemRefs(index, e))}
         onMouseEnter={() => setActiveItemIndex(index)}
-        onMouseDown={() => addToInputOnclick(index)}
+        onMouseDown={() => takeActionOnclick(index)}
         className={index === activeItemIndex ? 'active' : ''}
       >
         <span className="left">{item.tag}</span>

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -91,7 +91,7 @@ export function SearchBar(props: SearchBarProps) {
       } else if (e.key === 'Enter') {
         e.preventDefault();
         setShowAutoCompleteOptions(false);
-        if (activeItemIndex > inactiveItemsIndex) {
+        if (listValues.length && activeItemIndex > inactiveItemsIndex) {
           addToInput(listValues[activeItemIndex].tag);
         }
         sendSearchWord();

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { SearchBarProps } from '@/views/search/types/searchTypes';
+import { IStringIndexedObject, SearchBarProps } from '@/views/search/types/searchTypes';
 import {
   acceptableCharactersTest,
   stripBeforeLastComma,
@@ -34,7 +34,7 @@ export function SearchBar(props: SearchBarProps) {
   const [showAutoCompleteOptions, setShowAutoCompleteOptions] = useState(false);
   const [activeItemIndex, setActiveItemIndex] = useState(0);
   const [listValues, setListValues] = useState([]);
-  const itemRefs: React.MutableRefObject<{}> = useRef({});
+  const itemRefs: React.MutableRefObject<IStringIndexedObject> = useRef({});
 
   useEffect(() => {
     if (itemRefs.current[`${activeItemIndex}`]) {

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -91,7 +91,9 @@ export function SearchBar(props: SearchBarProps) {
       } else if (e.key === 'Enter') {
         e.preventDefault();
         setShowAutoCompleteOptions(false);
-        addToInput(listValues[activeItemIndex].tag);
+        if (activeItemIndex > inactiveItemsIndex) {
+          addToInput(listValues[activeItemIndex].tag);
+        }
         sendSearchWord();
       } else if (e.key === 'Escape') {
         e.preventDefault();

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -32,7 +32,8 @@ export function SearchBar(props: SearchBarProps) {
   const [hasSearchTerm, setHasSearchTerm] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [showAutoCompleteOptions, setShowAutoCompleteOptions] = useState(false);
-  const [activeItemIndex, setActiveItemIndex] = useState(0);
+  const inactiveItemsIndex: number = -1;
+  const [activeItemIndex, setActiveItemIndex] = useState(inactiveItemsIndex);
   const [listValues, setListValues] = useState([]);
   const itemRefs: React.MutableRefObject<IStringIndexedObject> = useRef({});
 
@@ -51,6 +52,7 @@ export function SearchBar(props: SearchBarProps) {
 
       if (filteredOptions.length > 0) {
         setListValues(filteredOptions);
+        setActiveItemIndex(inactiveItemsIndex);
         setShowAutoCompleteOptions(true);
       } else {
         setShowAutoCompleteOptions(false);
@@ -63,7 +65,6 @@ export function SearchBar(props: SearchBarProps) {
   const addToInput = (capturedTag: string) => {
     if (capturedTag !== '') {
       setListValues([]);
-      setActiveItemIndex(0);
       setInputValue('');
       searchInputRef.current.value = capturedTag;
     }
@@ -88,11 +89,12 @@ export function SearchBar(props: SearchBarProps) {
         e.preventDefault();
         setActiveItemIndex((prevIndex) => Math.min(prevIndex + 1, listValues.length - 1));
       } else if (e.key === 'Enter') {
-        if (showAutoCompleteOptions) {
+        if (showAutoCompleteOptions && activeItemIndex !== inactiveItemsIndex) {
           e.preventDefault();
           setShowAutoCompleteOptions(false);
           addToInput(listValues[activeItemIndex].tag);
         } else {
+          setShowAutoCompleteOptions(false);
           sendSearchWord();
         }
       } else if (e.key === 'Escape') {
@@ -100,7 +102,6 @@ export function SearchBar(props: SearchBarProps) {
         setShowAutoCompleteOptions(false);
         setInputValue('');
         setListValues([]);
-        setActiveItemIndex(0);
       }
     } else if (acceptableCharactersTest(e.key)) {
       updateSearchWord();

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -15,6 +15,7 @@ import { IoMdClose } from 'react-icons/io';
 import { useWh00tWebsocket } from '@/context/wh00tContext';
 import { Wh00tWindowStateEnum } from '@/context/types/enums';
 import { SearchContext } from '@/context/searchContext';
+import { TagWithCount } from '@/dataSource/types/apiTypes';
 import {
   ClearSearchButton,
   SearchAutoCompleteContainer,
@@ -45,7 +46,7 @@ export function SearchBar(props: SearchBarProps) {
   useEffect(() => {
     if (inputValue !== '') {
       const MAX_OPTIONS: number = 50;
-      const filteredOptions: string[] = searchContext.tags.filter((item) => item.includes(
+      const filteredOptions: TagWithCount[] = searchContext.tags.filter((item) => item.tag.includes(
         stripBeforeLastComma(inputValue),
       )).slice(0, MAX_OPTIONS);
 
@@ -57,6 +58,7 @@ export function SearchBar(props: SearchBarProps) {
       }
     } else {
       setShowAutoCompleteOptions(false);
+      setHasSearchTerm(false);
     }
   }, [inputValue]);
 
@@ -91,7 +93,7 @@ export function SearchBar(props: SearchBarProps) {
         if (showAutoCompleteOptions) {
           e.preventDefault();
           setShowAutoCompleteOptions(false);
-          addToInput(listValues[activeItemIndex]);
+          addToInput(listValues[activeItemIndex].tag);
         } else {
           sendSearchWord();
         }
@@ -120,7 +122,7 @@ export function SearchBar(props: SearchBarProps) {
   };
 
   const addToInputOnclick = (index: number) => {
-    addToInput(listValues[index]);
+    addToInput(listValues[index].tag);
     searchInputRef.current.focus();
   };
 
@@ -132,17 +134,20 @@ export function SearchBar(props: SearchBarProps) {
     setShowAutoCompleteOptions(false);
   };
 
-  const autoCompleteOptionList: JSX.Element[] = listValues.map((item: string, index: number) => (
-    <li
-      key={item}
-      ref={(e: HTMLLIElement) => (addToListItemRefs(index, e))}
-      onMouseEnter={() => setActiveItemIndex(index)}
-      onMouseDown={() => addToInputOnclick(index)}
-      className={index === activeItemIndex ? 'active' : ''}
-    >
-      {item}
-    </li>
-  ));
+  const autoCompleteOptionList: JSX.Element[] = listValues.map(
+    (item: TagWithCount, index: number) => (
+      <li
+        key={item.tag}
+        ref={(e: HTMLLIElement) => (addToListItemRefs(index, e))}
+        onMouseEnter={() => setActiveItemIndex(index)}
+        onMouseDown={() => addToInputOnclick(index)}
+        className={index === activeItemIndex ? 'active' : ''}
+      >
+        <span className="left">{item.tag}</span>
+        <span className="right">{item.count}</span>
+      </li>
+    ),
+  );
 
   return (
     <SearchWrapper onBlur={handleBlur}>

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -1,43 +1,114 @@
-import React, { KeyboardEvent, useRef, useState } from 'react';
+import React, {
+  ChangeEventHandler,
+  KeyboardEventHandler,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { SearchBarProps } from '@/views/search/types/searchTypes';
-import { acceptableCharactersTest } from '@/utils/utils';
+import {
+  acceptableCharactersTest,
+  stripBeforeLastComma,
+} from '@/utils/utils';
 import { IoMdClose } from 'react-icons/io';
 import { useWh00tWebsocket } from '@/context/wh00tContext';
 import { Wh00tWindowStateEnum } from '@/context/types/enums';
+import { SearchContext } from '@/context/searchContext';
 import {
   ClearSearchButton,
+  SearchAutoCompleteContainer,
   SearchButton,
   SearchContainer,
   SearchInput,
+  SearchWrapper,
 } from '../lexicon/styles/searchContainer';
 
 export function SearchBar(props: SearchBarProps) {
   const { searchSystem } = props;
-  const { state } = useWh00tWebsocket();
+  const wh00tContext = useWh00tWebsocket().state;
+  const searchContext = useContext(SearchContext).state;
   const searchInputRef: React.MutableRefObject<any> = useRef();
   const [hasSearchTerm, setHasSearchTerm] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [showAutoCompleteOptions, setShowAutoCompleteOptions] = useState(false);
+  const [activeItemIndex, setActiveItemIndex] = useState(0);
+  const [listValues, setListValues] = useState([]);
+  const itemRefs: React.MutableRefObject<{}> = useRef({});
 
-  const sendSearchWord = () => {
-    searchSystem.onSendSearch(searchInputRef.current.value);
+  useEffect(() => {
+    if (itemRefs.current[`${activeItemIndex}`]) {
+      itemRefs.current[`${activeItemIndex}`].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [activeItemIndex]);
+
+  useEffect(() => {
+    if (inputValue !== '') {
+      const MAX_OPTIONS: number = 50;
+      const filteredOptions: string[] = searchContext.tags.filter((item) => item.includes(
+        stripBeforeLastComma(inputValue),
+      )).slice(0, MAX_OPTIONS);
+
+      if (filteredOptions.length > 0) {
+        setListValues(filteredOptions);
+        setShowAutoCompleteOptions(true);
+      } else {
+        setShowAutoCompleteOptions(false);
+      }
+    } else {
+      setShowAutoCompleteOptions(false);
+    }
+  }, [inputValue]);
+
+  const addToInput = (capturedTag: string) => {
+    if (capturedTag !== '') {
+      setListValues([]);
+      setActiveItemIndex(0);
+      setInputValue('');
+      searchInputRef.current.value = capturedTag;
+    }
   };
+
+  const sendSearchWord = () => searchSystem.onSendSearch(searchInputRef.current.value);
   const updateSearchWord = () => {
     if (searchSystem.onSearchKeyUp) {
       searchSystem.onSearchKeyUp(searchInputRef.current.value);
     }
   };
 
-  const searchKeyInput = (event: KeyboardEvent) => {
-    if (searchInputRef.current.value) {
-      setHasSearchTerm(true);
-    } else {
-      setHasSearchTerm(false);
-    }
+  const onInputKeydown: KeyboardEventHandler = (e) => {
+    const specialKeys: string[] = ['ArrowUp', 'ArrowDown', 'Enter', 'Escape'];
+    setHasSearchTerm(Boolean(searchInputRef.current.value));
 
-    if (event.key === 'Enter') {
-      sendSearchWord();
-    } else if (acceptableCharactersTest(event.key)) {
+    if (specialKeys.includes(e.key)) {
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveItemIndex((prevIndex) => Math.max(prevIndex - 1, 0));
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveItemIndex((prevIndex) => Math.min(prevIndex + 1, listValues.length - 1));
+      } else if (e.key === 'Enter') {
+        if (showAutoCompleteOptions) {
+          e.preventDefault();
+          setShowAutoCompleteOptions(false);
+          addToInput(listValues[activeItemIndex]);
+        } else {
+          sendSearchWord();
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        setShowAutoCompleteOptions(false);
+        setInputValue('');
+        setListValues([]);
+        setActiveItemIndex(0);
+      }
+    } else if (acceptableCharactersTest(e.key)) {
       updateSearchWord();
     }
+  };
+
+  const onInputChange: ChangeEventHandler = () => {
+    setInputValue(searchInputRef.current.value);
   };
 
   const clearSearch = () => {
@@ -48,24 +119,55 @@ export function SearchBar(props: SearchBarProps) {
     searchInputRef.current.focus();
   };
 
+  const addToInputOnclick = (index: number) => {
+    addToInput(listValues[index]);
+    searchInputRef.current.focus();
+  };
+
+  const addToListItemRefs = (index: number, e: HTMLLIElement) => {
+    itemRefs.current[`${index}`] = e;
+  };
+
+  const handleBlur = () => {
+    setShowAutoCompleteOptions(false);
+  };
+
+  const autoCompleteOptionList: JSX.Element[] = listValues.map((item: string, index: number) => (
+    <li
+      key={item}
+      ref={(e: HTMLLIElement) => (addToListItemRefs(index, e))}
+      onMouseEnter={() => setActiveItemIndex(index)}
+      onMouseDown={() => addToInputOnclick(index)}
+      className={index === activeItemIndex ? 'active' : ''}
+    >
+      {item}
+    </li>
+  ));
+
   return (
-    <SearchContainer>
-      <SearchInput
-        title="Search Term Input"
-        type="text"
-        placeholder="Search Term"
-        ref={searchInputRef}
-        onKeyUp={searchKeyInput}
-        autoFocus
-        hasSearchTerm={hasSearchTerm}
-        rightSideWindowOpen={state.wh00tWindowState === Wh00tWindowStateEnum.MAX}
-      />
-      <ClearSearchButton hasSearchTerm={hasSearchTerm} onClick={clearSearch}>
-        <IoMdClose />
-      </ClearSearchButton>
-      <SearchButton title="Submit Search Term" onClick={sendSearchWord}>
-        Search
-      </SearchButton>
-    </SearchContainer>
+    <SearchWrapper onBlur={handleBlur}>
+      <SearchContainer>
+        <SearchInput
+          title="Search Term Input"
+          type="text"
+          placeholder="Search Term"
+          ref={searchInputRef}
+          onKeyDown={onInputKeydown}
+          onChange={onInputChange}
+          autoFocus
+          hasSearchTerm={hasSearchTerm}
+          rightSideWindowOpen={wh00tContext.wh00tWindowState === Wh00tWindowStateEnum.MAX}
+        />
+        <ClearSearchButton hasSearchTerm={hasSearchTerm} onClick={clearSearch}>
+          <IoMdClose />
+        </ClearSearchButton>
+        <SearchButton title="Submit Search Term" onClick={sendSearchWord}>
+          Search
+        </SearchButton>
+      </SearchContainer>
+      <SearchAutoCompleteContainer show={showAutoCompleteOptions}>
+        {autoCompleteOptionList}
+      </SearchAutoCompleteContainer>
+    </SearchWrapper>
   );
 }

--- a/src/views/search/lexicon/styles/searchContainer.ts
+++ b/src/views/search/lexicon/styles/searchContainer.ts
@@ -84,6 +84,16 @@ export const SearchAutoCompleteContainer = styled.ul<{ show: boolean }>`
   li {
     list-style: none;
     padding: 5px;
+    display: flex;
+    justify-content: space-between;
+
+    .left {
+      margin-left: 3px;
+    }
+
+    .right {
+      margin-right: 5px;
+    }
   }
 
   .active{

--- a/src/views/search/lexicon/styles/searchContainer.ts
+++ b/src/views/search/lexicon/styles/searchContainer.ts
@@ -74,6 +74,7 @@ export const SearchAutoCompleteContainer = styled.ul<{ show: boolean }>`
   color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.fontColor};
   font-size: 16px;
   position: absolute;
+  z-index: 1;
   padding: 10px 3px;
   margin:  -16px 0;
   max-height: 225px;

--- a/src/views/search/lexicon/styles/searchContainer.ts
+++ b/src/views/search/lexicon/styles/searchContainer.ts
@@ -4,6 +4,10 @@ import { Input } from '@/components/Input/Input';
 import { Button, ButtonProps } from '@/components/Nav/Button';
 import { device } from '@/styles/responsive';
 
+export const SearchWrapper = styled.div`
+  position: relative;
+`;
+
 export const SearchContainer = styled.menu`
   all: unset;
   font-size: 13px;
@@ -55,6 +59,37 @@ export const SearchInput = styled(Input)<{
     &:hover {
       color: ${(props: GlobalThemeType) => props.theme.lexicon.secondaryTextColor};
     }
+  }
+`;
+
+export const SearchAutoCompleteContainer = styled.ul<{ show: boolean }>`
+  display: ${(props) => (props.show ? 'block' : 'none')};
+  width: calc(100% - 91px);
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  border: 2px solid;
+  border-color: ${(props: GlobalThemeType) => props.theme.lexicon.searchBar.borderFocusColor};
+  border-top: 0;
+  background-color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.backgroundColor};
+  color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.fontColor};
+  font-size: 16px;
+  position: absolute;
+  padding: 10px 3px;
+  margin:  -16px 0;
+  max-height: 225px;
+  overflow-y: scroll;
+  box-shadow: 0 5px 5px rgba(0, 0, 0, .2);
+
+  li {
+    list-style: none;
+    padding: 5px;
+  }
+
+  .active{
+    background-color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.activeBackground};
+    color: ${(props: GlobalThemeType) => props.theme.input.autocompleteOptions.activeFontColor
+};
+    border-radius: 3px;
   }
 `;
 

--- a/src/views/search/lexicon/styles/searchContainer.ts
+++ b/src/views/search/lexicon/styles/searchContainer.ts
@@ -27,6 +27,7 @@ export const SearchInput = styled(Input)<{
   border-right: ${(props) => (props.hasSearchTerm ? 'none' : '')};;
   min-width: 100px;
   margin: 13px 0;
+  padding: 0 10px;
   border-radius: 5px 0 0 5px;
   transition: none;
 

--- a/src/views/search/styles/searchStyles.ts
+++ b/src/views/search/styles/searchStyles.ts
@@ -58,7 +58,7 @@ export const LatestTagsListContainer = styled.div`{
   flex-wrap: wrap;
   width: 100%;
   overflow: auto;
-  gap: 20px 10px;
+  gap: 10px;
   padding: 5px 0 5px 0;
 
   li {

--- a/src/views/search/types/searchTypes.ts
+++ b/src/views/search/types/searchTypes.ts
@@ -1,5 +1,9 @@
 import React from 'react';
 
+export interface IStringIndexedObject {
+  [key: string]: any
+}
+
 export type SearchSystem = {
   system: string,
   onHomeClick: CallableFunction,

--- a/src/views/search/types/searchTypes.ts
+++ b/src/views/search/types/searchTypes.ts
@@ -8,7 +8,7 @@ export type SearchSystem = {
 }
 
 export type SearchBarProps = {
-  searchSystem: SearchSystem
+  searchSystem: SearchSystem,
 }
 
 export enum ArcadiaView {

--- a/src/views/wh00t/components/Wh00tMessage/components/textTransform.tsx
+++ b/src/views/wh00t/components/Wh00tMessage/components/textTransform.tsx
@@ -6,8 +6,9 @@ import {
   ItalicText, TextMessage,
 } from '@/views/wh00t/components/Wh00tMessage/styles/wh00tMessageStyle';
 import React from 'react';
+import { BaseObjectOfFunctions } from '@/dataSource/types/apiTypes';
 
-const tokenTransforms: { [key: string]: Function } = {
+const tokenTransforms: BaseObjectOfFunctions = {
   '`': (text: string): JSX.Element => (<code key={randomUuid()}>{text}</code>),
   '*': (text: string): JSX.Element => (<BoldText key={randomUuid()}>{text}</BoldText>),
   '_': (text: string): JSX.Element => (<ItalicText key={randomUuid()}>{text}</ItalicText>),
@@ -19,7 +20,7 @@ export function noneTokenTextSpanElement(htmlText: string): JSX.Element {
 }
 
 export function textTransform(text: string): JSX.Element[] {
-  const transformTokens = Object.keys(tokenTransforms);
+  const transformTokens: string[] = Object.keys(tokenTransforms);
   const transformedTextArr: JSX.Element[] = [];
   let noneTokenText: string = '';
   let currentToken: string = null;

--- a/src/views/wh00t/utils/emojis.ts
+++ b/src/views/wh00t/utils/emojis.ts
@@ -1,6 +1,8 @@
 // Organized from https://emojipedia.org/
 
-export const EmojiOptions: { [key: string]: string } = {
+import { BaseObject } from '@/views/air/types/airTypes';
+
+export const EmojiOptions: BaseObject = {
   ':thumbsup:': '👍',
   ':thumbsdown:': '👎',
   ':clap:': '👏',

--- a/src/views/wh00t/utils/helpMenu.ts
+++ b/src/views/wh00t/utils/helpMenu.ts
@@ -1,4 +1,6 @@
-function helpMenuTableRow(commands: {[key: string]: string}): string {
+import { BaseObject } from '@/views/air/types/airTypes';
+
+function helpMenuTableRow(commands: BaseObject): string {
   return ''.concat(...Object.keys(commands).map(
     (command:string) => (`
     <tr>
@@ -13,7 +15,7 @@ function helpMenuTableGenerator(
   title: string,
   firstColumnTitle: string,
   secondColumnTitle: string,
-  commands: {[key: string]: string},
+  commands: BaseObject,
 ): string {
   return `
   <h2 class="tableHeader">${title}</h2>
@@ -35,7 +37,7 @@ export function helpMenu(): string {
     + 'that also has access to socket based connections.  It has no major external dependencies.  '
     + 'This makes it a pretty good local LAN chat system with chatbot support.';
 
-  const commands: {[key: string]: string} = {
+  const commands: BaseObject = {
     '/help, /h': 'Print out help menu',
     '/exit': 'Logout of chat',
     '/clear, /c': 'Clear chat history',
@@ -50,14 +52,14 @@ export function helpMenu(): string {
     '/arc': '🤖 Hyperlink bookmark and search chatbot',
   };
 
-  const formattingSymbols: {[key: string]: string} = {
+  const formattingSymbols: BaseObject = {
     '_word_': 'Word or phrase surrounded by a pair of spaced underscores is italicize',
     '*word*': 'Word or phrase surrounded by a pair of spaced asterisks is emboldened',
     '`word`': 'Word or phrase surrounded by spaced backticks is placed as inline code',
     '```word```': 'Word or phrase surrounded by 3 backticks is placed as a code block',
   };
 
-  const specialHandlers: {[key: string]: string} = {
+  const specialHandlers: BaseObject = {
     '[web_URL]': 'Any web address is shown in chat as a hyperlink that opens a new tab',
     '[image_URL]': 'Popular image type URLs are attempted to be shown as a scaled image or hyperlink',
   };


### PR DESCRIPTION
The purpose here is to build out a more classic search capability from scratch to set the framework for an enhanced search interface based on tags auto-completion.  This update supplies autocomplete for the add record form, the edit record form, and the general search bar.  With auto-completion of tags within the search results, the current known number of record under those tags are also supplied.  This update is meant to streamline the search and add record capabilities in order to make it faster to search and manage records.